### PR TITLE
Add integer coverage to buildExtraInputParameterRequest

### DIFF
--- a/src/main/java/com/emailage/javawrapper/model/ExtraInputParameter.java
+++ b/src/main/java/com/emailage/javawrapper/model/ExtraInputParameter.java
@@ -487,6 +487,11 @@ public class ExtraInputParameter {
 					double value = (double) prop.get(this);
 					sb.append(String.format("&%s=%f", prop.getName(), value));
 				}
+				} else if (prop.getType().toString().equals("int")) {
+					prop.setAccessible(true);
+					int value = (int) prop.get(this);
+					sb.append(String.format("&%s=%d", prop.getName(), value));
+				}
 			}
 		} catch(Exception e){
 			throw new EmailageParameterException("Could not parse extra input parameters for the request",e);


### PR DESCRIPTION
This will fix any future issues with 
`transactionTypeId`
`time_to_service`