### PR TITLE
Remove encoding of response

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-[logo]: https://www.emailage.com/wp-content/uploads/2018/01/logo-dark.svg "Emailage Logo"
 
-![Emailage](https://emailage.com/wp-content/uploads/2019/07/EmailageLogo143.png?raw=true)
-
-The Emailage&#8482; API is organized around REST (Representational State Transfer). The API was built to help companies integrate with our highly efficient fraud risk and scoring system. By calling our API endpoints and simply passing us an email and/or IP Address, companies will be provided with real-time risk scoring assessments based around machine learning and proprietary algorithms that evolve with new fraud trends.
+The [Emailage](https://risk.lexisnexis.co.uk/products/lexisnexis-emailage)&#8482; API is organized around REST (Representational State Transfer). The API was built to help companies integrate with our highly efficient fraud risk and scoring system. By calling our API endpoints and simply passing us an email and/or IP Address, companies will be provided with real-time risk scoring assessments based around machine learning and proprietary algorithms that evolve with new fraud trends.
 
 
 ## Getting Started
@@ -10,8 +7,7 @@ The Emailage&#8482; API is organized around REST (Representational State Transfe
 ### Requirements
 
 * JVM 1.8 and above
-* Maven 3+
-    * Maven is used to maintain all dependencies
+* Maven 3 and above for dependencies
 
 ### Installation
 
@@ -25,7 +21,7 @@ Or you can use the Maven dependency:
 <dependency>
   <groupId>com.emailage</groupId>
   <artifactId>classic-api-client</artifactId>
-  <version>1.2.0</version>
+  <version>X.X.X</version>
 </dependency>
 ```
 
@@ -83,4 +79,77 @@ String validResult = EmailageClient.MarkEmailAsFraud("test@test.com", Enums.Frau
 1. Using the wrong AccountSID/AUTHToken for different environments. Sandbox and Production have different AccountSID and AUTHToken.
 2. Using a wrong JVM version. JVM 1.8 and above is required for the client.
 
+## Option for Running Test Client Locally
 
+Recommendation for running the application locally against the `example/TestClient.java` is packaging the application into a Maven JAR file and running it in a docker dev container. In this example it is running in Visual Studio Code.
+
+**Step 1**: Include the necessary marven jar dependencies and configuration plugins into the `pom.xml` file
+
+```xml
+<plugin>
+    <!-- Build an executable JAR -->
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jar-plugin</artifactId>
+    <version>3.1.0</version>
+    <configuration>
+        <archive>
+            <manifest>
+                <mainClass>com.emailage.javawrapper.example.TestClient</mainClass>
+            </manifest>
+        </archive>
+    </configuration>
+</plugin>
+<plugin>
+ 	<!-- Configure a uber JAR to package all dependencies -->
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-shade-plugin</artifactId>
+    <version>3.2.4</version>
+    <executions>
+        <execution>
+            <phase>package</phase>
+            <goals>
+                <goal>shade</goal>
+            </goals>
+            <configuration>
+                <transformers>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                         <mainClass>com.emailage.javawrapper.example.TestClient</mainClass>
+                    </transformer>
+                </transformers>
+             </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+**Step 2**: Configure `TestClient.java` file
+
+The test client has hardcoded the production environment and the email query `test@test.com` which you are free to change.
+
+For credentials you will need to change the following fields for validate credentials to the environment you are targeting: Sandbox or Production
+```Java
+String accountSid = "replace-here"; //Consumer Key
+String authToken = "replace-here"; //Consumer Secret
+```
+
+**Step 3**: For added convience install docker and the Dev Container extension and run the application inside a dev container. The extention should give you an option for creating a configuration file but here is an example which will run
+
+```Json
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
+{
+    "name": "Java",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/java:1-21-bullseye",
+ 
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "none",
+            "installMaven": "true",
+            "installGradle": "false"
+        }
+    }
+}
+```
+
+This file should be added from the root under `.devcontainer/devcontainer.json`

--- a/src/main/java/com/emailage/javawrapper/EmailageClient.java
+++ b/src/main/java/com/emailage/javawrapper/EmailageClient.java
@@ -115,8 +115,7 @@ public class EmailageClient {
 		StringBuffer queryBuffer = new StringBuffer("query=");
 		queryBuffer.append(queryElement);
 		String result = PostQuery(APIUrl.Query,null, queryBuffer.toString(), parameters);
-		String decodedString =  java.net.URLDecoder.decode(result, StandardCharsets.UTF_8.name());
-		return deserialize(decodedString);
+		return deserialize(result);
 	}
 
 	/**
@@ -214,8 +213,7 @@ public class EmailageClient {
 				// Specify Fraud Type: Fraud or Good
 				+ "&flag=" + fraudType;
 		String result = PostQuery(APIUrl.MarkAsFraud, fraudType, query, parameters);
-		String decodedString =  java.net.URLDecoder.decode(result, StandardCharsets.UTF_8.name());
-		EmailageResponse response =  deserialize(decodedString);
+		EmailageResponse response =  deserialize(result);
 		response.getQuery().setEmail(java.net.URLDecoder.decode(response.getQuery().getEmail(), StandardCharsets.UTF_8.name()));
 
 		return response;

--- a/src/main/java/com/emailage/javawrapper/EmailageClient.java
+++ b/src/main/java/com/emailage/javawrapper/EmailageClient.java
@@ -90,8 +90,7 @@ public class EmailageClient {
 		validateParams(email, parameters.isValidateBeforeSending());
 		String query = "query=" + java.net.URLEncoder.encode(email, StandardCharsets.UTF_8.name());
 		String result = PostQuery(APIUrl.Query, null, query, parameters);
-		String decodedString =  java.net.URLDecoder.decode(result, StandardCharsets.UTF_8.name());
-		return deserialize(decodedString);
+		return deserialize(result);
 	}
 
 	/**


### PR DESCRIPTION
- Remove from the wrapper attempts to decode the response string. The wrapper should just pass back from the API exactly what it returns without attempting mutation.
- Enhanced the Readme for instructions on how to run locally against the TestClient