### PR TITLE
Add args to the gpg plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,10 @@
                         <configuration>
                             <keyname>28C37BD357582F61</keyname>
                             <passphraseServerId>28C37BD357582F61</passphraseServerId>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This was to get around an error in attempting to use the gpg key passphrase in the console (macOs)